### PR TITLE
Simple dockerfile to set up a windows container with cake installed

### DIFF
--- a/Windows/Nano/Dockerfile
+++ b/Windows/Nano/Dockerfile
@@ -1,0 +1,11 @@
+FROM microsoft/dotnet:2.1-sdk-nanoserver-1803
+
+ADD cake.cmd c:/cake/cake.cmd
+
+# Windows doesn't currently support setting PATH with ENV
+RUN setx PATH "C:\Program Files\dotnet;c:\cake;%PATH%"
+
+RUN dotnet --info \
+	&& dotnet tool install Cake.Tool --tool-path c:\cake \
+    && cake --info
+

--- a/Windows/Nano/cake.cmd
+++ b/Windows/Nano/cake.cmd
@@ -1,0 +1,1 @@
+@dotnet-cake.exe %*


### PR DESCRIPTION
Takes a CAKE_VERSION as --build-arg to support installing versions of
cake different from 0.30.0

There need to be some work on how to build it as part of the build. I'll be happy to look in to it, but I think I need someone to point me in the right direction.